### PR TITLE
Fix namespace name typo and add PR trigger for CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,6 +1,6 @@
 name: CI
 
-on: [push]
+on: [push, pull_request]
 
 jobs:
   phpunit:

--- a/tests/SDK/Library/AlbumTest.php
+++ b/tests/SDK/Library/AlbumTest.php
@@ -1,7 +1,7 @@
 <?php
 declare(strict_types = 1);
 
-namespace Tests\MusicComapnion\AppleMusic\SDK\Library;
+namespace Tests\MusicCompanion\AppleMusic\SDK\Library;
 
 use MusicCompanion\AppleMusic\SDK\Library\{
     Album,


### PR DESCRIPTION
# Changed log

- Add `pull_request` trigger on GitHub action.
- Add `Tests\MusicCompanion\AppleMusic\SDK\Library` namespace for `AlbumTest`class.